### PR TITLE
a11y: required field ARIA

### DIFF
--- a/foundationform/templates/foundationform/_foundation_form_field.html
+++ b/foundationform/templates/foundationform/_foundation_form_field.html
@@ -6,7 +6,7 @@
     {% if inline %}
         <div class="large-3 columns">
             <label for="{{ field.auto_id }}" class="right inline">
-                {{ field.label }} {% if field.field.required %}<span class="red">*</span>{% endif %}
+                {{ field.label }} {% if field.field.required %}<abbr class="red req" title="required">*</abbr>{% endif %}
             </label>
         </div>
         <div class="large-9 columns">
@@ -19,7 +19,7 @@
         <div class="large-12 columns">
             <label for="{{ field.auto_id }}">
                 {{ field.label }}
-                {% if field.field.required %}<span class="red">*</span>{% endif %}
+                {% if field.field.required %}<abbr class="red req" title="required">*</abbr>{% endif %}
                 {% if languages|length > 1 and field.name in form.translated_field_names %}
                     <small class="float-right">[{% trans 'translatable' %}]</small>
                 {% endif %}

--- a/foundationform/templates/foundationform/foundation_form.html
+++ b/foundationform/templates/foundationform/foundation_form.html
@@ -6,6 +6,8 @@
     </div>
 {% endif %}
 
+<p>Required fields are marked with <abbr class="red req" title="required">*</abbr>.</p>
+
 {% for field in form.hidden_fields %}
     {{ field }}
 {% endfor %}


### PR DESCRIPTION
This updates the `*` used for 'required' fields so that:
1. users are informed that `*` indicates a required field.
2. the `*` is marked as an abbreviation that means 'required' to assistive technologies.

The field itself is already marked up as required, and they will receive that information.   

This improves accessibility and compliance with [WCAG 3.3.2](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html).   It follows technique [H90](https://www.w3.org/WAI/WCAG22/Techniques/html/H90).

This introduces the class `req` for the asterisk, which the technique recommends is then used to increase the size of the symbol:

``` css
.req {font-size: 150%}

```

This is required as part of openlibhums/janeway#4482